### PR TITLE
Do not attempt to perform diffs if config is not wholly known

### DIFF
--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -590,7 +590,7 @@ func resourceJobCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta in
 	providerConfig := meta.(ProviderConfig)
 	client := providerConfig.client
 
-	if !d.NewValueKnown("jobspec") {
+	if !d.GetRawConfig().IsWhollyKnown() {
 		d.SetNewComputed("name")
 		d.SetNewComputed("modify_index")
 		d.SetNewComputed("namespace")


### PR DESCRIPTION
The jobspec might rely on `vars` that are not known at diff time so
don't attempt to parse it unless the entire config is known.